### PR TITLE
Use Foldable.toList to make compatible with logging-effect-1.2.0

### DIFF
--- a/src/Control/Monad/Log/Handler.hs
+++ b/src/Control/Monad/Log/Handler.hs
@@ -8,6 +8,7 @@ module Control.Monad.Log.Handler where
 
 import Control.Lens ((&), (.~))
 import Control.Retry (recovering, exponentialBackoff, logRetries, defaultLogMsg)
+import Data.Foldable (toList)
 import Data.Text (Text)
 import Network.Google (runResourceT, runGoogle, send, Error(TransportError, ServiceError))
 import Network.Google.Logging
@@ -41,7 +42,8 @@ withGoogleLoggingHandler
     -> (Handler io LogEntry -> io a)
     -> io a
 withGoogleLoggingHandler options env logname resource labels =
-    withBatchedHandler options (flushToGoogleLogging env logname resource labels)
+    withBatchedHandler options $ \entries ->
+        flushToGoogleLogging env logname resource labels (toList entries)
 
 
 -- | method for flash log to <https://cloud.google.com/logging/ Google Logging>
@@ -99,7 +101,8 @@ withGooglePubSubHandler
     -> (Handler io PubsubMessage -> io a)
     -> io a
 withGooglePubSubHandler options env topic =
-    withBatchedHandler options (flushToGooglePubSub env topic)
+    withBatchedHandler options $ \entries ->
+        flushToGooglePubSub env topic (toList entries)
 
 
 -- | method for flash log to <https://cloud.google.com/pubsub/ Google PubSub>


### PR DESCRIPTION
Thanks for some helpful and very nice looking code! I had not known about `Control.Retry`.

All this PR does is to use `toList` to paper over that the latest version of `logging-effect` uses `Data.List.NonEmpty`.

I also tested that this change builds with `lts-8.17` (which I'm using at work), `lts-8.24` (the latest in the 8.0.2 series), and `lts-9.0`. For these, I removed the extra-dep locking down to `logging-effect-1.1.0`.